### PR TITLE
Bootstrap bare metal servers from OpenTofu with flint-pxe

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,9 +11,9 @@
   "customizations": {
    "vscode": {
       "extensions": [
-         "ms-azuretools.vscode-docker",
-         "arrterian.nix-env-selector",
-         "gamunu.opentofu"
+        "ms-azuretools.vscode-docker",
+        "arrterian.nix-env-selector",
+        "gamunu.opentofu"
       ]
    }
   },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,8 @@
    "vscode": {
       "extensions": [
          "ms-azuretools.vscode-docker",
-         "arrterian.nix-env-selector"
+         "arrterian.nix-env-selector",
+         "gamunu.opentofu"
       ]
    }
   },

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,37 @@
+# direnv
 .direnv/
+
+# Local .terraform directories
+.terraform/
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore transient lock info files created by terraform apply
+.terraform.tfstate.lock.info
+
+# Include auto tfvars
+!*.auto.tfvars
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "ms-vscode-remote.remote-containers",
+        "bbenoist.Nix",
+        "ms-azuretools.vscode-containers",
+        "gamunu.opentofu"
+    ]
+}

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735563628,
-        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "lastModified": 1750400657,
+        "narHash": "sha256-3vkjFnxCOP6vm5Pm13wC/Zy6/VYgei/I/2DWgW4RFeA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "rev": "b2485d56967598da068b5a6946dadda8bfcbcd37",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "feenx-infra";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -19,6 +19,16 @@
             docker-compose
             neovim
             wakeonlan
+            talosctl
+            kubectl
+            helm
+            opentofu
+
+            # Alias scripts, workaround for https://github.com/direnv/direnv/issues/73
+            (pkgs.writeShellScriptBin "tf" "tofu $@")
+            (pkgs.writeShellScriptBin "tctl" "talosctl $@")
+            (pkgs.writeShellScriptBin "k" "kubectl $@")
+            (pkgs.writeShellScriptBin "h" "helm $@")
           ];
         };
       }

--- a/infra/live/prod/.terraform.lock.hcl
+++ b/infra/live/prod/.terraform.lock.hcl
@@ -1,0 +1,46 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/kreuzwerker/docker" {
+  version     = "3.6.2"
+  constraints = "3.6.2"
+  hashes = [
+    "h1:1K3j0xUY2D0+E+DBDQc6k1u6Al9MkuNWrIC9rnvwFSM=",
+    "zh:22b51a8fb63481d290bdad9a221bc8c9e45d66d1a0cd45beed3f3627bf1debd8",
+    "zh:2b902eb80a1ae033af1135cc165d192668820a7f8ea15beb5472f811c18bea1f",
+    "zh:57815dcea28aedb86ed33924cd186aaee8bd31670bd78437a2a2daf2b00ce2ae",
+    "zh:583af9c6fe7e3bfc04f50aec046a9b4f98b7eddd6d1e143454e5d06a66afcf87",
+    "zh:80f8cba54f639a53c4d7714edb7246064b7f4f48ba93a70f18c914d656d799db",
+    "zh:894709f0c393c4ee91fdb849128e7f0bce688f293cd1643a6d4e39c842367278",
+    "zh:a91b41dbcb203d6dae2bb72b98c4c21c41255026b35df01895882784c4650071",
+    "zh:aec40a8157aae093412a1fb9a71ab2bea370db152e285c2d81e37ed378444b9c",
+    "zh:b87d7def2485dde6e57723c1265158f371440a8a84954c9fdb0580cf89de66bf",
+    "zh:b9dc243200ad9cd00250cb8c793ecea4ee3c57a121faf8efdb289f30008b5778",
+    "zh:dcb103831db6d3ef95468685cd104be3928793996542a1f675dc34a2ce67951d",
+    "zh:e59b4a0f2b5881016896d4417b1ab2fb87f34450663efeb01f3bcf7c3606fbbb",
+    "zh:fbd068c01114f0712578cf02f363b5521338ab1befedddf7090da532298b43d0",
+  ]
+}
+
+provider "registry.opentofu.org/siderolabs/talos" {
+  version     = "0.9.0-alpha.0"
+  constraints = "0.9.0-alpha.0"
+  hashes = [
+    "h1:aJIAbggkIN/2/7JEjSz/PfHVFRXOokeHYt3hDII6kI0=",
+    "zh:0fa82a384b25a58b65523e0ea4768fa1212b1f5cfc0c9379d31162454fedcc9d",
+    "zh:12a822ecfcc14da28bb88887811a796f5165ee50d64967c5afea389da12e3d18",
+    "zh:5c2519abfbd5e45de4afd94e52d393235e3d09845af27c58aa98dd532311f47f",
+    "zh:6a99b169eaf46789c7465de27d2dea52ca799f39412390d0a28bb28f5b9e5a4e",
+    "zh:975daeb0ff5517e5a7a4357125f6e7d74041d87c853f9a52ecfd285ce972e51b",
+    "zh:b358aefccccf84dab4bf07f2b039814755fc282cbe30f20496013e311eae3463",
+    "zh:b4e3a0fddc38a05c25b8f1553098574d56959abeb2b5bf9e880208000a415231",
+    "zh:ba331d61225fac3f787f7acd4cc298a7e0ca43ee7536ce5ab7f6c9dfae4c8e9e",
+    "zh:bbd9bc936461d2be6c11a5abaa53f2618ac592bc7a6cc1ad9c4205fd73c95eac",
+    "zh:bdd77e81bf65074fbc891a7429ec3264a342bc7545978a6c108e87cec5bb2f56",
+    "zh:c132d34502d47436c5f31670f2c786c072bce6137e28cfb5d948f36721db5f66",
+    "zh:c39ac5467fff7e326b31ada5e734ba88b8f811c5d758c3ce2c9c886504cc232f",
+    "zh:f1083b82593be4c888e35f6c9c773a86551c8c7b5dac1f3fa69863820852fc87",
+    "zh:f40bc8da36b6dc3b95cc13d208b81e254346d78ab81624c07a2fa74148de7a8b",
+    "zh:f56b4589644078e21dbcdbb53cc278550a04fa9c02bc7eea3f5dc91648da2048",
+  ]
+}

--- a/infra/live/prod/main.tf
+++ b/infra/live/prod/main.tf
@@ -1,0 +1,12 @@
+# Locals
+locals {
+  bootstrap_node = one([for n in var.talos_nodes : n.hostname if n.bootstrap])
+}
+
+# Modules
+module "flint_pxe" {
+  source         = "../../modules/flint_pxe"
+  network_subnet = "10.10.97.1/24"
+  wait_time      = 180
+  talos_nodes    = var.talos_nodes
+}

--- a/infra/live/prod/terraform.auto.tfvars
+++ b/infra/live/prod/terraform.auto.tfvars
@@ -1,0 +1,24 @@
+talos_nodes = {
+  nx0 = {
+    hostname        = "nx0.feenx.io"
+    mac_address     = "58:47:CA:7F:E2:16"
+    wake_on_lan_mac = "58:47:CA:7F:E2:14"
+    install_disk    = "/dev/nvme0n1"
+    role            = "controlplane"
+    bootstrap       = true
+  },
+  nx1 = {
+    hostname        = "nx1.feenx.io"
+    mac_address     = "58:47:CA:7F:D3:B6"
+    wake_on_lan_mac = "58:47:CA:7F:D3:B4"
+    install_disk    = "/dev/nvme0n1"
+    role            = "controlplane"
+  },
+  nx2 = {
+    hostname        = "nx2.feenx.io"
+    mac_address     = "58:47:CA:7F:D7:7E"
+    wake_on_lan_mac = "58:47:CA:7F:D7:7C"
+    install_disk    = "/dev/nvme0n1"
+    role            = "controlplane"
+  }
+}

--- a/infra/live/prod/variables.tf
+++ b/infra/live/prod/variables.tf
@@ -1,0 +1,9 @@
+variable "talos_nodes" {
+  type = map(object({
+    hostname        = string
+    mac_address     = string
+    wake_on_lan_mac = string
+    install_disk    = string
+    bootstrap       = optional(bool, false)
+  }))
+}

--- a/infra/modules/flint_pxe/main.tf
+++ b/infra/modules/flint_pxe/main.tf
@@ -1,0 +1,66 @@
+# Locals
+locals {
+  factory_base_url     = "https://factory.talos.dev"
+  talos_version_latest = element(data.talos_image_factory_versions.this.talos_versions, length(data.talos_image_factory_versions.this.talos_versions) - 1)
+  talos_version        = coalesce(var.talos_version, local.talos_version_latest)
+  base_args = [
+    "--wait", var.wait_time,
+    "--talos-version", local.talos_version,
+    "--schematic-id", talos_image_factory_schematic.this.id,
+    "--network", var.network_subnet
+  ]
+  wol_args       = flatten([for n in var.talos_nodes : ["-m", n.wake_on_lan_mac]])
+  flint_pxe_args = concat(local.base_args, local.wol_args)
+}
+
+# Data
+data "talos_image_factory_versions" "this" {
+  filters = {
+    stable_versions_only = true
+  }
+}
+
+data "talos_image_factory_extensions_versions" "this" {
+  talos_version = local.talos_version
+  filters = {
+    names = [
+      "amdgpu"
+    ]
+  }
+}
+
+data "docker_registry_image" "flint_pxe_registry_image" {
+  name = "ghcr.io/feenx-lab/flint-pxe:latest" #TODO: Lock version
+}
+
+# Resources
+resource "talos_image_factory_schematic" "this" {
+  schematic = yamlencode(
+    {
+      customization = {
+        systemExtensions = {
+          officialExtensions = data.talos_image_factory_extensions_versions.this.extensions_info.*.name
+        }
+      }
+    }
+  )
+}
+
+resource "docker_image" "flint_pxe_image" {
+  name          = data.docker_registry_image.flint_pxe_registry_image.name
+  pull_triggers = [data.docker_registry_image.flint_pxe_registry_image.sha256_digest]
+}
+
+resource "docker_container" "flint_pxe_container" {
+  name         = "ephemeral-flint-pxe"
+  image        = docker_image.flint_pxe_image.image_id
+  start        = true
+  network_mode = "host"
+  capabilities {
+    add = [
+      "NET_ADMIN"
+    ]
+  }
+
+  command = local.flint_pxe_args
+}

--- a/infra/modules/flint_pxe/providers.tf
+++ b/infra/modules/flint_pxe/providers.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "3.6.2"
+    }
+    talos = {
+      source  = "siderolabs/talos"
+      version = "0.9.0-alpha.0"
+    }
+  }
+}

--- a/infra/modules/flint_pxe/variables.tf
+++ b/infra/modules/flint_pxe/variables.tf
@@ -1,0 +1,43 @@
+variable "talos_platform" {
+  description = "Platform to use to get the talos iPXE"
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "talos_version" {
+  description = "Version to use for Talos' image, format: vX.Y.Z"
+  type        = string
+  nullable    = true
+  default     = null
+
+  validation {
+    condition     = var.talos_version == null ? true : can(regex("^v[0-9]+.[0-9]+.[0-9]+"), var.talos_version)
+    error_message = "talos_version needs to be prefixed with 'v', e.g 'v10.1.4' is valid, '10.1.4' is invalid"
+  }
+}
+
+variable "talos_architecture" {
+  description = "Architecture to be used for the Talos Image Factory"
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "network_subnet" {
+  description = "CIDR notation of the DHCP server present in your network, e.g 192.168.1.1/24"
+  type        = string
+}
+
+variable "wait_time" {
+  description = "How much time to wait (in seconds), for the flint-pxe to auto-shutdown"
+  type        = number
+}
+
+variable "talos_nodes" {
+  description = "Map of Talos nodes with hostname and mac_address properties"
+  type = map(object({
+    hostname        = string
+    wake_on_lan_mac = string
+  }))
+}


### PR DESCRIPTION
### Changes
* Upgraded nixpkgs to 25.05
* Updated the nix flake to include `talosctl`, `helm`, `opentofu`
* Added some default alias shell scripts for the new tools
* Adding basic folder structure for OpenTofu code
* Setting up the flint-pxe module to boot the container with a wait time so that it auto destroys and sends wake on lan packets.

### Added OpenTofu providers:
* kreuzwerker/docker
* siderolabs/talos